### PR TITLE
Refactor for php 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 php:
-  - 7.0
-  - 7.1
-  - 7.2
+  - 8.0
   - nightly
 env:
   - PREFER_LOWEST="--prefer-lowest --prefer-stable"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Utilities to assist with [PSR-16 SimpleCache](http://www.php-fig.org/psr/psr-16/
 
 ## Requirements
 
-Requires PHP 7.0 (or later).
+Requires PHP 8.0 (or later).
 
 ## Composer
 To add the library as a local, per-project dependency use [Composer](http://getcomposer.org)! Simply add a dependency on `subjective-php/psr-cache-helper` to your project's `composer.json` file such as:

--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,12 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.0",
+        "php": "^8.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.1",
-        "phpunit/phpunit": "^6.1",
+        "phpunit/phpunit": "^9.3",
         "squizlabs/php_codesniffer": "^3.3"
     },
     "autoload": {
@@ -22,7 +22,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "SubjectivePHP\\Psr\\SimpleCache\\": "tests"
+            "SubjectivePHPTest\\Psr\\SimpleCache\\": "tests"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,17 @@
-<phpunit colors="true" forceCoversAnnotation="true">
-    <testsuites>
-        <testsuite name="PHP Library Test Suite">
-            <directory suffix="Test.php">tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-clover" target="./clover.xml"/>
-    </logging>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" forceCoversAnnotation="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>src</directory>
+    </include>
+    <report>
+      <clover outputFile="./clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP Library Test Suite">
+      <directory suffix="Test.php">tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/tests/InMemoryCacheTest.php
+++ b/tests/InMemoryCacheTest.php
@@ -26,7 +26,7 @@ final class InMemoryCacheTest extends \PHPUnit\Framework\TestCase
     /**
      * @return void
      */
-    public function setUp()
+    public function setUp() : void
     {
         $this->container = new ArrayObject();
         $this->cache = new InMemoryCache($this->container);

--- a/tests/KeyValidatorTraitTest.php
+++ b/tests/KeyValidatorTraitTest.php
@@ -6,7 +6,6 @@ use SubjectivePHP\Psr\SimpleCache\KeyValidatorTrait;
 
 /**
  * @coversDefaultClass \SubjectivePHP\Psr\SimpleCache\KeyValidatorTrait
- * @covers ::<private>
  */
 final class KeyValidatorTraitTest extends \PHPUnit\Framework\TestCase
 {
@@ -28,13 +27,13 @@ final class KeyValidatorTraitTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      * @covers ::validateKey
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
      * @dataProvider provideInvalidKeys
      *
      * @return void
      */
     public function validateKeyWithInvalidValue($key)
     {
+        $this->expectException(\Psr\SimpleCache\InvalidArgumentException::class);
         $this->validateKey($key);
     }
 
@@ -54,13 +53,13 @@ final class KeyValidatorTraitTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      * @covers ::validateKeys
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
      * @dataProvider provideInvalidKeys
      *
      * @return void
      */
     public function validateKeysWithInvalidValue($key)
     {
+        $this->expectException(\Psr\SimpleCache\InvalidArgumentException::class);
         $this->validateKeys(['valid_key', $key, 'another_valid_key']);
     }
 

--- a/tests/NullCacheTest.php
+++ b/tests/NullCacheTest.php
@@ -23,7 +23,7 @@ final class NullCacheTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp() : void
     {
         $this->cache = new NullCache();
     }

--- a/tests/Serializer/BasicSerializerTest.php
+++ b/tests/Serializer/BasicSerializerTest.php
@@ -28,13 +28,14 @@ final class BasicSerializerTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      * @covers ::unserialize
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
-     * @expectedExceptionMessage unserialize(): Error at offset 34 of 34 bytes
      *
      * @return void
      */
     public function unserializeInvalidData()
     {
+        $this->expectException(\Psr\SimpleCache\InvalidArgumentException::class);
+        $this->expectExceptionMessage('unserialize(): Error at offset 34 of 34 bytes');
+
         $serializer = new BasicSerializer();
         $serializer->unserialize('a:2:{s:3:"foo";s:3:"abc";s:3:"bar"');
     }
@@ -42,13 +43,14 @@ final class BasicSerializerTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      * @covers ::unserialize
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
-     * @expectedExceptionMessage $data must be a string
      *
      * @return void
      */
     public function unserializeNonStringData()
     {
+        $this->expectException(\Psr\SimpleCache\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$data must be a string');
+
         $serializer = new BasicSerializer();
         $serializer->unserialize(true);
     }
@@ -71,13 +73,14 @@ final class BasicSerializerTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      * @covers ::serialize
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
-     * @expectedExceptionMessage Serialization of 'Closure' is not allowed
      *
      * @return void
      */
     public function serializeFilure()
     {
+        $this->expectException(\Psr\SimpleCache\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Serialization of 'Closure' is not allowed");
+
         $serializer = new BasicSerializer();
         $serializer->serialize(
             function () {

--- a/tests/Serializer/JsonSerializerTest.php
+++ b/tests/Serializer/JsonSerializerTest.php
@@ -41,13 +41,14 @@ final class JsonSerializerTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      * @covers ::unserialize
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
-     * @expectedExceptionMessage Syntax error
      *
      * @return void
      */
     public function unserializeFailure()
     {
+        $this->expectException(\Psr\SimpleCache\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Syntax error');
+
         $serializer = new JsonSerializer();
         $json = '{"foo": "abc","bar": 123';
         $serializer->unserialize($json);
@@ -74,13 +75,14 @@ JSON;
     /**
      * @test
      * @covers ::serialize
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
-     * @expectedExceptionMessage Inf and NaN cannot be JSON encoded
      *
      * @return void
      */
     public function serializeFailure()
     {
+        $this->expectException(\Psr\SimpleCache\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Inf and NaN cannot be JSON encoded');
+
         $serializer = new JsonSerializer();
         $serializer->serialize(['foo' => NAN]);
     }

--- a/tests/Serializer/NullSerializerTest.php
+++ b/tests/Serializer/NullSerializerTest.php
@@ -20,7 +20,7 @@ final class NullSerializerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp() : void
     {
         $this->serializer = new NullSerializer();
     }

--- a/tests/TTLValidatorTraitTest.php
+++ b/tests/TTLValidatorTraitTest.php
@@ -6,7 +6,6 @@ use SubjectivePHP\Psr\SimpleCache\TTLValidatorTrait;
 
 /**
  * @coversDefaultClass \SubjectivePHP\Psr\SimpleCache\TTLValidatorTrait
- * @covers ::<private>
  */
 final class TTLValidatorTraitTest extends \PHPUnit\Framework\TestCase
 {
@@ -45,13 +44,14 @@ final class TTLValidatorTraitTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      * @covers ::validateTTL
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
      * @dataProvider provideInvalidTTLs
      *
      * @return void
      */
     public function validateTTLWithInvalidValue($ttl)
     {
+        $this->expectException(\Psr\SimpleCache\InvalidArgumentException::class);
+
         $this->validateTTL($ttl);
     }
 


### PR DESCRIPTION
hi i would like to continue using this project in PHP 8
can we update the composer php requirement to `^8.0`

#### What does this PR do?
set required PHP version to `^8.0`
update `phpunit/phpunit` to `^9.3`

#### Checklist
- [x] Pull request contains a clear definition of changes
- [x] Tests (either unit, integration, or acceptance) written and passing
- [x] Relevant documentation produced and/or updated
