### PR TITLE
Allow older versions of PHP

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 phpunit.xml
 phpcs.xml
+.*

--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,11 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.0||^8.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.3",
+        "phpunit/phpunit": ">=6.5",
         "squizlabs/php_codesniffer": "^3.3"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,13 @@
 <?xml version="1.0"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" forceCoversAnnotation="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory>src</directory>
-    </include>
-    <report>
-      <clover outputFile="./clover.xml"/>
-    </report>
-  </coverage>
   <testsuites>
     <testsuite name="PHP Library Test Suite">
       <directory suffix="Test.php">tests</directory>
     </testsuite>
   </testsuites>
-  <logging/>
+  <filter>
+    <whitelist>
+        <directory>src</directory>
+    </whitelist>
+  </filter>
 </phpunit>

--- a/tests/KeyValidatorTraitTest.php
+++ b/tests/KeyValidatorTraitTest.php
@@ -68,13 +68,13 @@ final class KeyValidatorTraitTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function provideInvalidKeys() : array
+    public static function provideInvalidKeys() : array
     {
         return [
-            ['an empty string' => ''],
-            ['an object' => new \StdClass()],
-            ['an integer' => 123],
-            ['reserved characters' => '@key'],
+            [''],
+            [new \StdClass()],
+            [123],
+            ['@key'],
         ];
     }
 }

--- a/tests/NullCacheTest.php
+++ b/tests/NullCacheTest.php
@@ -12,23 +12,6 @@ use SubjectivePHP\Psr\SimpleCache\NullCache;
 final class NullCacheTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * NullCache instance to use in tests.
-     *
-     * @var NullCache
-     */
-    private $cache;
-
-    /**
-     * Prepare each test
-     *
-     * @return void
-     */
-    public function setUp() : void
-    {
-        $this->cache = new NullCache();
-    }
-
-    /**
      * Verify basic behavior of get().
      *
      * @test
@@ -38,8 +21,9 @@ final class NullCacheTest extends \PHPUnit\Framework\TestCase
      */
     public function get()
     {
+        $cache = new NullCache();
         $default = new \StdClass();
-        $this->assertSame($default, $this->cache->get('a key', $default));
+        $this->assertSame($default, $cache->get('a key', $default));
     }
 
     /**
@@ -52,7 +36,8 @@ final class NullCacheTest extends \PHPUnit\Framework\TestCase
      */
     public function set()
     {
-        $this->assertTrue($this->cache->set('a key', 'some data'));
+        $cache = new NullCache();
+        $this->assertTrue($cache->set('a key', 'some data'));
     }
 
     /**
@@ -65,7 +50,8 @@ final class NullCacheTest extends \PHPUnit\Framework\TestCase
      */
     public function delete()
     {
-        $this->assertTrue($this->cache->delete('a key'));
+        $cache = new NullCache();
+        $this->assertTrue($cache->delete('a key'));
     }
 
     /**
@@ -78,7 +64,8 @@ final class NullCacheTest extends \PHPUnit\Framework\TestCase
      */
     public function clear()
     {
-        $this->assertTrue($this->cache->clear());
+        $cache = new NullCache();
+        $this->assertTrue($cache->clear());
     }
 
     /**
@@ -91,10 +78,11 @@ final class NullCacheTest extends \PHPUnit\Framework\TestCase
      */
     public function getMultiple()
     {
+        $cache = new NullCache();
         $default = new \StdClass();
         $this->assertSame(
             ['key1' => $default, 'key2' => $default],
-            $this->cache->getMultiple(['key1', 'key2'], $default)
+            $cache->getMultiple(['key1', 'key2'], $default)
         );
     }
 
@@ -108,7 +96,8 @@ final class NullCacheTest extends \PHPUnit\Framework\TestCase
      */
     public function setMultiple()
     {
-        $this->assertTrue($this->cache->setMultiple(['key' => 'some data', 'key2' => 'some more data']));
+        $cache = new NullCache();
+        $this->assertTrue($cache->setMultiple(['key' => 'some data', 'key2' => 'some more data']));
     }
 
     /**
@@ -121,7 +110,8 @@ final class NullCacheTest extends \PHPUnit\Framework\TestCase
      */
     public function deleteMultiple()
     {
-        $this->assertTrue($this->cache->deleteMultiple(['key1', 'key2']));
+        $cache = new NullCache();
+        $this->assertTrue($cache->deleteMultiple(['key1', 'key2']));
     }
 
     /**
@@ -134,6 +124,7 @@ final class NullCacheTest extends \PHPUnit\Framework\TestCase
      */
     public function has()
     {
-        $this->assertFalse($this->cache->has('key1'));
+        $cache = new NullCache();
+        $this->assertFalse($cache->has('key1'));
     }
 }

--- a/tests/Serializer/NullSerializerTest.php
+++ b/tests/Serializer/NullSerializerTest.php
@@ -11,21 +11,6 @@ use SubjectivePHP\Psr\SimpleCache\Serializer\NullSerializer;
 final class NullSerializerTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var NullSerializer
-     */
-    private $serializer;
-
-    /**
-     * Prepare each test
-     *
-     * @return void
-     */
-    public function setUp() : void
-    {
-        $this->serializer = new NullSerializer();
-    }
-
-    /**
      * @test
      * @covers ::unserialize
      *
@@ -33,8 +18,9 @@ final class NullSerializerTest extends \PHPUnit\Framework\TestCase
      */
     public function unserialize()
     {
+        $serializer = new NullSerializer();
         $data = ['foo' => 'abc', 'bar' => 123];
-        $this->assertSame($data, $this->serializer->unserialize($data));
+        $this->assertSame($data, $serializer->unserialize($data));
     }
 
     /**
@@ -45,7 +31,8 @@ final class NullSerializerTest extends \PHPUnit\Framework\TestCase
      */
     public function serialize()
     {
+        $serializer = new NullSerializer();
         $data = ['foo' => 'abc', 'bar' => 123];
-        $this->assertSame($data, $this->serializer->serialize($data));
+        $this->assertSame($data, $serializer->serialize($data));
     }
 }

--- a/tests/TTLValidatorTraitTest.php
+++ b/tests/TTLValidatorTraitTest.php
@@ -30,12 +30,12 @@ final class TTLValidatorTraitTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function provideValidTTLs()
+    public static function provideValidTTLs()
     {
         return [
-            ['null' => null],
-            ['DateInterval' => \DateInterval::createFromDateString('1 day')],
-            ['int' => 3600],
+            [null],
+            [\DateInterval::createFromDateString('1 day')],
+            [3600],
         ];
     }
 
@@ -60,12 +60,12 @@ final class TTLValidatorTraitTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function provideInvalidTTLs()
+    public static function provideInvalidTTLs()
     {
         return [
-            ['string' => ''],
-            ['float' => 1.1],
-            ['DdateTime' => new \DateTime()],
+            [''],
+            [1.1],
+            [new \DateTime()],
         ];
     }
 }


### PR DESCRIPTION
#### What does this PR do?
This pull request removes the backwards breaking change that removed support for PHP > 7.4
#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
